### PR TITLE
Feat: Automatically add Chartmuseum as Helm repository

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -75,6 +75,7 @@ jobs:
           cache_key_suffix: '-test'
           # Needed for short-lived containers otherwise testing is too late
           check_service: false
+          helm_repo_name: ''
 
       - name: "Running local action: ${{ github.repository }} [Run script]"
         uses: ./
@@ -84,6 +85,7 @@ jobs:
           script: 'job.sh'
           enable_cache: true
           cache_key_suffix: '-test'
+          helm_repo_name: ''
 
       - name: "Running local action: ${{ github.repository }} [Failure test]"
         uses: ./
@@ -97,7 +99,7 @@ jobs:
           cache_key_suffix: '-test'
           # Needed when failure testing; container exists before check runs
           check_service: false
-
+          helm_repo_name: ''
         continue-on-error: true
 
       - name: "Validate previous step failure"
@@ -122,6 +124,7 @@ jobs:
           cache_key_suffix: '-test'
           # Disable service check for persistent containers to avoid deadlocks
           check_service: false
+          helm_repo_name: ''
 
       - name: "Verify background container still running and accessible"
         shell: bash
@@ -272,23 +275,6 @@ jobs:
           echo "ChartMuseum URL: $CHARTMUSEUM_URL"
           echo "Container ID: $CONTAINER_ID"
 
-          # Wait for ChartMuseum to be ready
-          echo "Waiting for ChartMuseum to be ready..."
-          for i in {1..30}; do
-            if curl -f -s -m 5 -u "chartmuseum:$1" \
-              "$CHARTMUSEUM_URL/index.yaml" > /dev/null; then
-              echo "ChartMuseum is ready! ✅"
-              break
-            fi
-            if [ $i -eq 30 ]; then
-              echo "ChartMuseum failed to become ready ❌"
-              docker logs "$CONTAINER_ID" --tail 20
-              exit 1
-            fi
-            echo "Attempt $i/30: ChartMuseum not ready yet, waiting..."
-            sleep 2
-          done
-
           # Upload the chart using curl
           echo "Uploading chart to ChartMuseum..."
           cd test-chart-repo
@@ -351,51 +337,29 @@ jobs:
           exit: false
 
       # Additional verification - test with helm repo commands
-      - name: 'Test helm repo integration'
+      - name: 'Test availability with Helm commands'
         shell: bash
         run: |
-          # Test helm repo integration
-          CONTAINER_ID="${{ steps.upload_test_container.outputs.cid }}"
+          # Test availability with Helm commands
 
-          if [ -n "$CONTAINER_ID" ]; then
-            CONTAINER_IP=$(docker inspect \
-              -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
-              "$CONTAINER_ID")
-            CHARTMUSEUM_URL="http://$CONTAINER_IP:8084"
+          # Repository was configured automatically by action
+          helm repo list
+          # However, we need to rebuild the repository database
+          helm repo update
+          # Only then can we search for the chart uploaded by cURL
+          helm search repo chartmuseum
 
-            echo "Testing helm repo integration..."
-
-            # Add the ChartMuseum as a helm repository
-            helm repo add test-chartmuseum "$CHARTMUSEUM_URL" \
-              --username chartmuseum \
-              --password "${{ secrets.github_token }}"
-
-            # Update helm repositories
-            helm repo update
-
-            # Search for the uploaded chart
-            if helm search repo test-chartmuseum/test-chart; then
-              echo "Chart found via helm search! ✅"
-            else
-              echo "Chart not found via helm search ❌"
-              exit 1
-            fi
-
-            # Test pulling the chart with helm
-            mkdir -p /tmp/helm-test
-            cd /tmp/helm-test
-            if helm pull test-chartmuseum/test-chart; then
-              echo "Chart pulled successfully via helm! ✅"
-              ls -la test-chart-*.tgz
-            else
-              echo "Chart pull failed ❌"
-              exit 1
-            fi
-
-            echo "Helm repo integration test passed! 🎉"
+          # Test pulling the chart with helm
+          mkdir -p /tmp/helm-test
+          cd /tmp/helm-test
+          if helm pull chartmuseum/test-chart; then
+            echo "Chart pulled successfully via helm! ✅"
+            ls -la test-chart-*.tgz
           else
-            echo "Container ID not available, skipping helm repo test"
+            echo "Chart pull failed ❌"
+            exit 1
           fi
+          echo "Helm repo integration test passed! 🎉"
 
       # Cleanup: Terminate the persistent ChartMuseum container
       - name: 'Cleanup ChartMuseum container'

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ builds and follow-up runs:
 | debug            | False    | false       | Enables Docker container debugging                         |
 | enable_cache     | False    | true        | Enable Docker layer caching for faster builds              |
 | cache_key_suffix | False    |             | Extra suffix for cache keys to allow cache isolation       |
+| helm_repo_name   | False    | chartmuseum | Sets up Chartmuseum as a named helm repository             |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -114,9 +115,10 @@ builds and follow-up runs:
 
 <!-- markdownlint-disable MD013 -->
 
-| Name | Description                                 |
-| ---- | ------------------------------------------- |
-| cid  | Container ID of running Chartmuseum service |
+| Name         | Description                                       |
+| ------------ | ------------------------------------------------- |
+| cid          | Container ID of running Chartmuseum service       |
+| container_ip | IP address where Chartmuseum service is available |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/action.yaml
+++ b/action.yaml
@@ -79,11 +79,20 @@ inputs:
     required: false
     # type: 'string'
     default: ''
+  helm_repo_name:
+    description: 'Sets up Chartmuseum as a named helm repository'
+    required: false
+    # Disable by setting to empty string in calling workflow
+    default: 'chartmuseum'
+    # type: 'string'
 
 outputs:
   cid:
     description: "Running container ID"
     value: ${{ steps.chartmuseum.outputs.cid }}
+  container_ip:
+    description: "IP address of the running container"
+    value: ${{ steps.chartmuseum.outputs.container_ip }}
 
 runs:
   using: "composite"
@@ -170,11 +179,11 @@ runs:
       id: chartmuseum
       shell: bash
       run: |
-        # Start ChartMuseum with enhanced caching
+        # Start ChartMuseum
         # Configure Docker to use cache-from for faster container starts
         export DOCKER_BUILDKIT=1
 
-        echo "Starting ChartMuseum container with caching optimizations..."
+        echo "Starting ChartMuseum..."
         docker run -d --name chartmuseum --cidfile /tmp/chartmuseum.cid --rm \
           -p ${{ inputs.port }}:${{ inputs.port }} \
           -e DOCKER_BUILDKIT=1 \
@@ -191,25 +200,27 @@ runs:
             echo "Error: failed to start ChartMuseum container ❌"
             exit 1
           }
-        echo "Started ChartMuseum container with the following parameters:"
+
+        # Capture container ID and IP address
+        cid=$(cat /tmp/chartmuseum.cid)
+        container_ip=$(docker inspect -f \
+          '{{.NetworkSettings.IPAddress}}' chartmuseum)
+
+        echo "cid=$cid" >> "$GITHUB_ENV"
+        echo "cid=$cid" >> "$GITHUB_OUTPUT"
+        echo "container_ip=$container_ip" >> "$GITHUB_ENV"
+        echo "container_ip=$container_ip" >> "$GITHUB_OUTPUT"
+
+        echo "ChartMuseum Container ☸️"
+        echo "IP address: $container_ip"
         echo "Port: ${{ inputs.port }}"
         echo "Directory: ${{ inputs.directory }}"
         echo "Version: ${{ inputs.version }}"
         echo "Debug mode: ${{ inputs.debug }}"
-        CID=$(cat /tmp/chartmuseum.cid)
-        echo "cid=$CID" >> "$GITHUB_ENV"
-        echo "cid=$CID" >> "$GITHUB_OUTPUT"
-
-        # Give the service a moment to initialize
-        echo "Waiting for ChartMuseum service to initialize..."
-        sleep 3
-
-    - name: "Check container is running"
-      shell: bash
-      run: |
-        # Check container is running
         echo "Docker container status 💬"
         docker ps -f name=chartmuseum
+        echo "Helm Repositories:"
+        helm repo list || true
 
     # Do NOT replace this availability check with a simple cURL command
     - name: "Check service availability"
@@ -217,15 +228,31 @@ runs:
       # yamllint disable-line rule:line-length
       uses: lfreleng-actions/http-api-tool-docker@6b063866da92d2ef7d997d3376ed75fc0df95acf # Latest
       with:
-        url: 'http://localhost:${{ inputs.port }}/health'
-        auth_string: '${{ inputs.username }}:${{ inputs.password }}'
+        url: "http://${{ env.container_ip}}:${{ inputs.port }}/health"
+        auth_string: "${{ inputs.username }}:${{ inputs.password }}"
         service_name: 'ChartMuseum'
         expected_http_code: '200'
         retries: '5'
         initial_sleep_time: '2'
         curl_timeout: '10'
         max_response_time: '5'
-        debug: '${{ inputs.debug }}'
+        debug: "${{ inputs.debug }}"
+
+    - name: "Adding Chartmuseum Helm repository: ${{ inputs.helm_repo_name }}"
+      if: inputs.helm_repo_name != ''
+      shell: bash
+      run: |
+        # Add as named Helm repository
+        helm repo add "${{ inputs.helm_repo_name }}" \
+          "http://${{ env.container_ip }}:${{ inputs.port }}" \
+          --username "${{ inputs.username }}" \
+          --password "${{ inputs.password }}"
+        helm repo update
+        echo "Added as Helm repository: ${{ inputs.helm_repo_name }}" \
+          >> "$GITHUB_STEP_SUMMARY"
+        echo "Added as Helm repository: ${{ inputs.helm_repo_name }}"
+        echo "Listing Helm repositories ☸️"
+        helm repo list
 
     - name: "Running ChartMuseum for: ${{ inputs.exec_time }}s"
       if: inputs.script == '' && inputs.exit == 'true'


### PR DESCRIPTION
Automatically add Chartmuseum service as Helm repo.
Enumerate container IP hosting Chartmuseum from Docker.
Adds container's hosted IP address as an action output.
Remove fixed three second sleep time after container startup.
Streamline tests, remove redundant/duplicated steps.