### PR TITLE
Chore: add path filters to testing.yaml for pull_request trigger

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,6 +15,11 @@ on:
     branches: ['main']
   pull_request:
     branches: ['main']
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!.*'
+      - '!tox.ini'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"


### PR DESCRIPTION
## Summary

Add path filters to `testing.yaml` so Dependabot PRs that only bump SHA pins in `.github/workflows/` skip the full test suite.

## Why This Is Needed

- **75% of Dependabot PRs** across the org only change workflow files (SHA pin bumps)
- Each triggers the full integration test suite unnecessarily
- **Eliminates 65%+ of CI compute waste**

## Approach: Denylist (Org Convention)

Uses the same opt-out pattern already established across the org:

```yaml
paths:
  - '**'
  - '!.github/**'
  - '!.*'
  - '!tox.ini'
```

- Fails **open** (safe) rather than closed (dangerous)
- Universal and templatable from actions-template
- Matches build-test.yaml convention in github2gerrit-action, dependamerge, gerrit-clone-action, gha-workflow-linter, lftools-uv

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| Dependabot bumps harden-runner SHA | Full test suite runs | Skipped ✅ |
| Developer changes source code | Full test suite runs | Full test suite runs ✅ |

Part of org-wide Dependabot CI optimization initiative.