### PR TITLE
Fix: resolve zizmor auditor persona findings

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,16 +20,26 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -13,6 +13,13 @@ on:
 
 permissions: {}
 
+# Serialise repeated runs for the same tag; never cancel an in-flight
+# release promotion. Distinct tags use distinct groups and proceed
+# independently.
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: false
+
 jobs:
   validate_tag:
     name: 'Validate Tag'
@@ -25,11 +32,22 @@ jobs:
     outputs:
       tag: "${{ steps.tag_validate.outputs.tag_name }}"
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -53,14 +71,25 @@ jobs:
     needs: validate_tag
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: write  # Promote (publish) the draft release for the tag
     timeout-minutes: 5
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -38,6 +38,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       # Cache Docker layers for ChartMuseum container (aligned with action)
       - name: 'Cache Docker layers'
@@ -56,10 +58,12 @@ jobs:
       # Pre-pull ChartMuseum Docker image for caching
       - name: 'Pre-pull ChartMuseum Docker image'
         shell: bash
+        env:
+          CHARTMUSEUM_VERSION: ${{ env.chartmuseum-version }}
         run: |
           # Pre-pull ChartMuseum Docker image
           echo "Pre-pulling ChartMuseum Docker image for caching..."
-          docker pull ghcr.io/helm/chartmuseum:${{ env.chartmuseum-version }}
+          docker pull "ghcr.io/helm/chartmuseum:$CHARTMUSEUM_VERSION"
           echo "ChartMuseum image cached successfully ✅"
 
       - name: 'Create local job to execute'
@@ -133,9 +137,11 @@ jobs:
 
       - name: "Verify background container still running and accessible"
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+          CONTAINER_ID: ${{ steps.persistent_container.outputs.cid }}
         run: |
           # Verify background container still running and accessible
-          CONTAINER_ID="${{ steps.persistent_container.outputs.cid }}"
           echo "Container ID from action output: $CONTAINER_ID"
 
           if [ -z "$CONTAINER_ID" ]; then
@@ -163,7 +169,7 @@ jobs:
             "$CONTAINER_ID")
           echo "Testing accessibility on container IP: $CONTAINER_IP"
 
-          if curl -f -s -m 5 -u "chartmuseum:${{ secrets.github_token }}" \
+          if curl -f -s -m 5 -u "chartmuseum:$GITHUB_TOKEN" \
             "http://$CONTAINER_IP:8083/index.yaml" > /dev/null; then
             echo "✅ ChartMuseum service is accessible and responding correctly!"
           else
@@ -183,6 +189,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       # Cache Docker layers for ChartMuseum container (aligned with action)
       - name: 'Cache Docker layers'
@@ -200,10 +208,12 @@ jobs:
       # Pre-pull ChartMuseum Docker image for caching
       - name: 'Pre-pull ChartMuseum Docker image'
         shell: bash
+        env:
+          CHARTMUSEUM_VERSION: ${{ env.chartmuseum-version }}
         run: |
           # Pre-pull ChartMuseum Docker image
           echo "Pre-pulling ChartMuseum Docker image for caching..."
-          docker pull ghcr.io/helm/chartmuseum:${{ env.chartmuseum-version }}
+          docker pull "ghcr.io/helm/chartmuseum:$CHARTMUSEUM_VERSION"
           echo "ChartMuseum image cached successfully ✅"
 
       # Install Helm for chart operations
@@ -394,6 +404,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       # Check if act is available and install if possible
       - name: 'Setup nektos/act for local testing'
@@ -424,13 +436,15 @@ jobs:
       # Run the workflow locally with act
       - name: 'Test workflow with nektos/act'
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
         run: |
           # Test workflow with nektos/act
           if command -v act &> /dev/null; then
             echo "Running workflow tests with nektos/act..."
 
             # Create a minimal .env file for act if needed
-            echo "GITHUB_TOKEN=${{ secrets.github_token }}" > .env
+            echo "GITHUB_TOKEN=$GITHUB_TOKEN" > .env
 
             # Run only the basic tests job with act
             echo "Testing basic functionality with act..."


### PR DESCRIPTION
## Summary

Resolves the zizmor **auditor** persona findings (`min-severity: low`)
that fail the organisation's required "Audit Workflows" gate and block
Dependabot pull requests from merging.

## Method

- **Boilerplate workflows** (`tag-push`, `release-drafter`) that carried
  findings were replaced byte-for-byte with the canonical versions from
  `actions-template`. This adds the workflow-level `concurrency` group
  (`concurrency-limits`), harden-runner block-mode egress via
  `harden-runner-block-action`, and documented permission scopes
  (`undocumented-permissions`).
- **Repository-specific workflows** were adjusted in place to match the
  canonical patterns: `${{ ... }}` expressions hoisted out of `run:`
  blocks into intermediate environment variables
  (`template-injection`), workflow-level `concurrency` groups
  (`concurrency-limits`), `persist-credentials: false` on checkout
  steps (`artipacked`) where flagged, and explanatory comments on
  permission scopes (`undocumented-permissions`).

Verified with `zizmor --persona auditor --min-severity low` (clean),
with no action pin downgrades.
